### PR TITLE
fix: Adicionar badge de ownership em tarefas carregadas inicialmente

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -200,8 +200,9 @@ func handleTasksPage(listTasks *usecases.ListTasksUseCase) http.HandlerFunc {
 		))
 
 		data := map[string]interface{}{
-			"Title": "Tarefas",
-			"Tasks": tasks,
+			"Title":  "Tarefas",
+			"Tasks":  tasks,
+			"UserID": userID,
 		}
 
 		if err := tmpl.Execute(w, data); err != nil {

--- a/internal/infrastructure/templates/tasks.html
+++ b/internal/infrastructure/templates/tasks.html
@@ -47,6 +47,11 @@
                                 {{ else if eq .Status "in_progress" }}Em Progresso
                                 {{ else }}Concluída{{ end }}
                             </span>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                                {{ if eq .OwnerID $.UserID }}bg-blue-100 text-blue-800
+                                {{ else }}bg-purple-100 text-purple-800{{ end }}">
+                                {{ if eq .OwnerID $.UserID }}Própria{{ else }}Compartilhada{{ end }}
+                            </span>
                             <span class="text-sm text-gray-500">{{ .CreatedAt.Format "02/01/2006 15:04" }}</span>
                         </div>
                     </div>


### PR DESCRIPTION
## Resumo

Corrige a **Issue #9** - Badge de propriedade (Própria/Compartilhada) não aparecia em tarefas carregadas no load inicial da página.

## Problema

**Comportamento inconsistente:**
- ❌ Tarefas no load inicial → **SEM badge**
- ✅ Tarefas criadas via HTMX → **COM badge**
- ✅ Tarefas concluídas via HTMX → **COM badge**

**Causa Raiz:**
- Templates duplicados renderizando HTML de formas diferentes
- `tasks.html` (Go template) → Renderiza load inicial **sem badge**
- `templates.go` (HTMX) → Renderiza ações dinâmicas **com badge**

## Solução Implementada

### 1. Passar UserID para Template

**`cmd/server/main.go` (handleTasksPage):**
```go
// Antes:
data := map[string]interface{}{
    "Title": "Tarefas",
    "Tasks": tasks,
}

// Depois:
data := map[string]interface{}{
    "Title":  "Tarefas",
    "Tasks":  tasks,
    "UserID": userID, // ✅ Adicionar UserID
}
```

### 2. Adicionar Badge no Template Estático

**`internal/infrastructure/templates/tasks.html`:**
```html
<div class="mt-2 flex items-center space-x-2">
    <!-- Badge de Status -->
    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
        {{ if eq .Status "pending" }}bg-yellow-100 text-yellow-800
        {{ else if eq .Status "in_progress" }}bg-blue-100 text-blue-800
        {{ else }}bg-green-100 text-green-800{{ end }}">
        {{ if eq .Status "pending" }}Pendente
        {{ else if eq .Status "in_progress" }}Em Progresso
        {{ else }}Concluída{{ end }}
    </span>
    
    <!-- ✅ Badge de Ownership (NOVO) -->
    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
        {{ if eq .OwnerID $.UserID }}bg-blue-100 text-blue-800
        {{ else }}bg-purple-100 text-purple-800{{ end }}">
        {{ if eq .OwnerID $.UserID }}Própria{{ else }}Compartilhada{{ end }}
    </span>
    
    <span class="text-sm text-gray-500">{{ .CreatedAt.Format "02/01/2006 15:04" }}</span>
</div>
```

**Nota técnica:** Uso de `$.UserID` (não `.UserID`) para acessar o UserID do contexto raiz do template, já que estamos dentro do loop `{{ range .Tasks }}`.

## Resultado

**Agora o badge aparece em TODOS os cenários:**
- ✅ Tarefas no load inicial da página
- ✅ Tarefas criadas via HTMX
- ✅ Tarefas concluídas via HTMX

**Cores consistentes:**
- 🔵 **Própria** (`bg-blue-100 text-blue-800`) - quando `OwnerID == UserID`
- 🟣 **Compartilhada** (`bg-purple-100 text-purple-800`) - quando `OwnerID != UserID`

## Arquivos Modificados

| Arquivo | Mudanças | Descrição |
|---------|----------|-----------|
| `cmd/server/main.go` | +3, -2 | Passar UserID para template data |
| `internal/infrastructure/templates/tasks.html` | +5, -0 | Adicionar badge de ownership |

**Total:** +8 linhas, -2 linhas

## Testes Manuais

**Cenário 1: Load Inicial**
1. Login na aplicação
2. Página carrega com tarefas existentes
3. ✅ **Verificado:** Badge de ownership aparece

**Cenário 2: Criar Tarefa (HTMX)**
1. Criar nova tarefa via formulário
2. ✅ **Verificado:** Badge aparece (comportamento já existente)

**Cenário 3: Concluir Tarefa (HTMX)**
1. Clicar em "Concluir" em uma tarefa
2. ✅ **Verificado:** Badge permanece visível (comportamento já existente)

**Cenário 4: Refresh da Página**
1. Recarregar página (F5)
2. ✅ **Verificado:** Badge continua aparecendo (FIX principal!)

## Decisão Técnica

**Por que não unificar os templates?**

Optei pela **Opção 1 (Quick Fix)** ao invés da Opção 2 (Unificar templates) porque:

✅ **Prós da Opção 1:**
- Mudança mínima e focada
- Menos invasiva
- Risco reduzido
- Resolve o problema imediatamente
- Mantém separação Go template vs HTMX

❌ **Contras da Opção 2:**
- Refatoração maior
- Mais pontos de falha
- Maior complexidade
- Não adiciona valor funcional

**Conclusão:** Quick fix é suficiente para este caso. Unificação pode ser considerada em refatoração futura se necessário.

## Relação com PRs Anteriores

- **PR #8:** Implementou badges de ownership nos templates HTMX ✅
- **Issue #9:** Identificou que badges não apareciam no load inicial ❌
- **Este PR:** Adiciona badges no template estático (Go) ✅

Agora a funcionalidade está **100% completa**.

## Checklist

- [x] Problema analisado e causa raiz identificada
- [x] Solução implementada (Opção 1 - Quick Fix)
- [x] UserID passado para template
- [x] Badge adicionado em tasks.html
- [x] Testes manuais realizados (4 cenários)
- [x] Comportamento consistente em todos os casos
- [x] Documentação do PR completa

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)