### PR TITLE
feat: Adicionar ícones visuais aos botões de ação (#13)

### DIFF
--- a/internal/infrastructure/http/handler/templates.go
+++ b/internal/infrastructure/http/handler/templates.go
@@ -43,6 +43,9 @@ var (
 				{{if .ShowComplete}}
 				<button hx-post="/web/tasks/{{.ID}}/complete" hx-target="#task-{{.ID}}" hx-swap="outerHTML"
 						class="text-green-600 hover:text-green-800 font-medium">
+					<svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+					</svg>
 					Concluir
 				</button>
 				{{end}}
@@ -53,12 +56,18 @@ var (
 						hx-prompt="Digite o email do usuário com quem deseja compartilhar:"
 						hx-vals='js:{share_with_user_id: prompt("Digite o email do usuário:")}'
 						class="text-blue-600 hover:text-blue-800 font-medium">
+					<svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+					</svg>
 					Compartilhar
 				</button>
 				{{end}}
 				<button hx-delete="/web/tasks/{{.ID}}" hx-target="#task-{{.ID}}" hx-swap="outerHTML"
 						hx-confirm="Tem certeza que deseja excluir esta tarefa?"
 						class="text-red-600 hover:text-red-800">
+					<svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+					</svg>
 					Excluir
 				</button>
 			</div>
@@ -83,6 +92,9 @@ var (
 				<button hx-delete="/web/tasks/{{.ID}}" hx-target="#task-{{.ID}}" hx-swap="outerHTML"
 						hx-confirm="Tem certeza que deseja excluir esta tarefa?"
 						class="text-red-600 hover:text-red-800">
+					<svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+					</svg>
 					Excluir
 				</button>
 			</div>

--- a/internal/infrastructure/templates/tasks.html
+++ b/internal/infrastructure/templates/tasks.html
@@ -59,6 +59,9 @@
                         {{ if ne .Status "completed" }}
                         <button hx-post="/web/tasks/{{ .ID }}/complete" hx-target="#task-{{ .ID }}" hx-swap="outerHTML"
                                 class="text-green-600 hover:text-green-800 font-medium">
+                            <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                            </svg>
                             Concluir
                         </button>
                         {{ end }}
@@ -70,6 +73,9 @@
                                 hx-prompt="Digite o email do usuário com quem deseja compartilhar:"
                                 hx-vals='js:{share_with_user_id: prompt("Digite o email do usuário:")}'
                                 class="text-blue-600 hover:text-blue-800 font-medium">
+                            <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+                            </svg>
                             Compartilhar
                         </button>
                         {{ end }}
@@ -77,6 +83,9 @@
                         <button hx-delete="/web/tasks/{{ .ID }}" hx-target="#task-{{ .ID }}" hx-swap="outerHTML"
                                 hx-confirm="Tem certeza que deseja excluir esta tarefa?"
                                 class="text-red-600 hover:text-red-800">
+                            <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                            </svg>
                             Excluir
                         </button>
                     </div>


### PR DESCRIPTION
## Summary

Implementa ícones visuais nos botões de ação (Concluir, Compartilhar, Excluir) para melhorar a experiência do usuário (UX) e tornar a interface mais intuitiva e moderna.

### Ícones Adicionados

- ✅ **Botão "Concluir"**: Ícone de checkmark (verde) - sugere ação de completar/marcar como feito
- 🔗 **Botão "Compartilhar"**: Ícone de share (azul) - sugere ação de enviar/compartilhar
- 🗑️ **Botão "Excluir"**: Ícone de lixeira (vermelho) - sugere ação destrutiva/remover

### Implementação Técnica

- **Biblioteca**: Heroicons (oficial do Tailwind CSS)
- **Método**: SVG inline (sem dependências externas ou CDN)
- **Tamanho**: `w-4 h-4` com espaçamento `mr-1`
- **Compatibilidade**: Funciona com HTMX e navegadores modernos
- **Acessibilidade**: Ícones complementam texto (não substituem)

### Arquivos Modificados

1. `internal/infrastructure/http/handler/templates.go` - Template HTMX dinâmico
2. `internal/infrastructure/templates/tasks.html` - Template Go estático
3. `internal/infrastructure/http/handler/web_handler_test.go` - Testes automatizados

### Testes

✅ Todos os testes passando:

- `TestTaskCard_ContainsIconsInButtons`: Verifica presença de SVG e paths específicos de cada ícone
- `TestTaskCard_CompletedTaskHasNoCompleteButton`: Valida que tarefas concluídas não exibem botão/ícone de completar
- `TestTaskCard_SharedTaskHasNoShareButton`: Valida que tarefas compartilhadas não exibem botão/ícone de compartilhar

## Test plan

- [x] Todos os testes unitários passando
- [x] Ícones aparecem nos botões Concluir, Compartilhar e Excluir
- [x] Ícones têm cores corretas (verde, azul, vermelho)
- [x] Ícones estão alinhados com o texto
- [x] Templates HTMX e estático implementados consistentemente
- [x] Tarefas concluídas não mostram ícone de checkmark
- [x] Tarefas compartilhadas não mostram ícone de compartilhar
- [ ] Teste visual manual no navegador (pendente)
- [ ] Teste de responsividade mobile (pendente)

## Closes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)