### PR TITLE
fix: Remover link 'Compartilhadas' da navegação (#15)

### DIFF
--- a/internal/infrastructure/http/handler/web_handler_test.go
+++ b/internal/infrastructure/http/handler/web_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -637,6 +638,32 @@ func TestWebShareTask_ShareButtonNotPresentInStaticTemplate(t *testing.T) {
 	// This test will fail until we implement the share button in tasks.html
 	// It's a placeholder to remind us to add the button to the static template
 	t.Skip("TODO: Add share button to tasks.html template")
+}
+
+// =============================================================================
+// Navigation Tests (for Issue #15)
+// =============================================================================
+
+func TestBaseTemplate_NoCompartilhadasLink(t *testing.T) {
+	// This test verifies that the base.html template does NOT contain
+	// the "Compartilhadas" link in the navigation bar
+	// Read the actual template file
+	content, err := os.ReadFile("../../../../internal/infrastructure/templates/base.html")
+	if err != nil {
+		t.Fatalf("Failed to read base.html: %v", err)
+	}
+
+	html := string(content)
+
+	// Verify that "Compartilhadas" link is NOT in the template
+	// The navigation bar should only contain "Minhas Tarefas"
+	if strings.Contains(html, "/tasks/shared") {
+		t.Error("base.html should NOT contain '/tasks/shared' link")
+	}
+
+	if strings.Contains(html, ">Compartilhadas<") {
+		t.Error("base.html should NOT contain 'Compartilhadas' link text")
+	}
 }
 
 // =============================================================================

--- a/internal/infrastructure/templates/base.html
+++ b/internal/infrastructure/templates/base.html
@@ -20,7 +20,6 @@
                 </div>
                 <div class="flex items-center space-x-4">
                     <a href="/tasks" class="text-gray-700 hover:text-gray-900">Minhas Tarefas</a>
-                    <a href="/tasks/shared" class="text-gray-700 hover:text-gray-900">Compartilhadas</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove o link "Compartilhadas" do canto superior direito da interface (navegação)
- Adiciona teste para verificar ausência do link no template base.html
- Simplifica a UI removendo link não utilizado

## Test plan
- [x] Teste criado e passando: `TestBaseTemplate_NoCompartilhadasLink`
- [x] Teste verifica que `/tasks/shared` não está presente no template
- [x] Teste verifica que o texto "Compartilhadas" não está presente no template
- [x] Todos os testes existentes continuam passando
- [ ] Testar visualmente a interface e confirmar que o link foi removido

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)